### PR TITLE
Copy public files to dist/public

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ ifneq ($(wildcard $(ASSETS_DIR)/.),)
 	cp -r $(ASSETS_DIR) dist/$(PLUGIN_ID)/
 endif
 ifneq ($(HAS_PUBLIC),)
-	cp -r public/ dist/$(PLUGIN_ID)/
+	cp -r public/ dist/$(PLUGIN_ID)/public/
 endif
 ifneq ($(HAS_SERVER),)
 	mkdir -p dist/$(PLUGIN_ID)/server/dist;


### PR DESCRIPTION
The Makefile now copies the public files to the correct place.

Confirmed that the example public file included does get served after building and installing the plugin.